### PR TITLE
Fix SysEx clock problem

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -184,7 +184,7 @@ func (s *Stream) Read(max int) (events []Event, err error) {
 			Data2:     (int64(buffer[i].message) >> 16) & 0xFF,
 		}
 
-		if event.Status&0xF0 == 0xF0 {
+		if event.Status == 0xF0 {
 			// Sysex message starts with 0xF0, ends with 0xF7
 			read := 0
 			for i+read < numEvents {


### PR DESCRIPTION
The SysEx messages start with 0xF0, clock message 0xF8 breaks this